### PR TITLE
[BUG] Fixing the Monotonization #16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ saved_predictions
 final_experiments/figs/
 final_experiments/*.csv
 monotonicity_*
+experiments/

--- a/tests/od/test_optim.py
+++ b/tests/od/test_optim.py
@@ -1,0 +1,6 @@
+def test_first_optim():
+    pass
+
+
+def test_second_optim():
+    pass


### PR DESCRIPTION
The mononotization trick used in cods.od.optim is computed on the risk, rather than the individual losses, causing, most likely, the guarantee to be invalid. This PR provides:

1.     a fix for this issue,
2.     a global check and cleaning of the file and
3.     some optimization to reduce computation time.
